### PR TITLE
Added NTLM-Authentication-Support

### DIFF
--- a/certsrv.py
+++ b/certsrv.py
@@ -53,18 +53,18 @@ def _get_response(username, password, url, data, auth_method='basic'):
 
     # Add Authentication specific headers or handlers to opener
     if auth_method == "ntlm":
-      from ntlm import HTTPNtlmAuthHandler
+        from ntlm import HTTPNtlmAuthHandler
 
-      passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
-      passman.add_password(None, url, username, password)
-      auth_handler = HTTPNtlmAuthHandler.HTTPNtlmAuthHandler(passman)
-      opener.add_handler(auth_handler)
+        passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
+        passman.add_password(None, url, username, password)
+        auth_handler = HTTPNtlmAuthHandler.HTTPNtlmAuthHandler(passman)
+        opener.add_handler(auth_handler)
     else:
       # Do Basic-Auth by Headers instead of HTTPBasicAuthHandler, because the handler
       # makes and additional 401 challange before sending credentials, which doubles the
       # requests unnecessarily
-      auth_string = 'Basic %s' % urllib2.base64.b64encode('%s:%s' % (username, password))
-      headers.append(('Authorization', auth_string))
+        auth_string = 'Basic %s' % urllib2.base64.b64encode('%s:%s' % (username, password))
+        headers.append(('Authorization', auth_string))
 
     # Add headers and Install opener
     opener.addheaders = headers
@@ -72,14 +72,14 @@ def _get_response(username, password, url, data, auth_method='basic'):
 
     # Make the request now
     response = urllib2.urlopen(url, data)
-    
+
     # The response code is not validated when using the HTTPNtlmAuthHandler
     # so we have to check it ourselves
-    if response.getcode() is 200:
-      return response
+    if response.getcode() == 200:
+        return response
     else:
         raise urllib2.HTTPError(response.url, response.getcode(), response.msg,
-                              response.headers, response.fp)
+                                response.headers, response.fp)
 
 def get_cert(server, csr, template, username, password, encoding='b64', auth_method='basic'):
     """
@@ -195,7 +195,9 @@ def get_ca_cert(server, username, password, encoding='b64', auth_method='basic')
     # We have to check how many renewals this server has had, so that we get the newest CA cert
     renewals = re.search(r'var nRenewals=(\d+);', response_page).group(1)
 
-    cert_url = 'https://%s/certsrv/certnew.cer?ReqID=CACert&Renewal=%s&Enc=%s' % (server, renewals, encoding)
+    cert_url = 'https://%s/certsrv/certnew.cer?ReqID=CACert&Renewal=%s&Enc=%s' % (server,
+                                                                                  renewals,
+                                                                                  encoding)
     response = _get_response(username, password, cert_url, None, auth_method)
     cert = response.read()
     return cert
@@ -244,11 +246,11 @@ def check_credentials(server, username, password, auth_method='basic'):
     url = 'https://%s/certsrv/' % server
 
     try:
-      response = _get_response(username, password, url, None, auth_method)
+        _get_response(username, password, url, None, auth_method)
     except urllib2.HTTPError as error:
-      if error.code == 401:
-        return False
-      else:
-        raise
+        if error.code == 401:
+            return False
+        else:
+            raise
     else:
         return True

--- a/certsrv.py
+++ b/certsrv.py
@@ -73,11 +73,13 @@ def _get_response(username, password, url, data, auth_method='basic'):
     # Make the request now
     response = urllib2.urlopen(url, data)
     
-    # Check HTTP Status Code
+    # The response code is not validated when using the HTTPNtlmAuthHandler
+    # so we have to check it ourselves
     if response.getcode() is 200:
       return response
-    else: 
-      return None
+    else:
+        raise urllib2.HTTPError(response.url, response.getcode(), response.msg,
+                              response.headers, response.fp)
 
 def get_cert(server, csr, template, username, password, encoding='b64', auth_method='basic'):
     """
@@ -243,10 +245,10 @@ def check_credentials(server, username, password, auth_method='basic'):
 
     try:
       response = _get_response(username, password, url, None, auth_method)
-      if response.getcode() is 200:
-        return True
     except urllib2.HTTPError as error:
       if error.code == 401:
         return False
       else:
         raise
+    else:
+        return True

--- a/test_certsrv.py
+++ b/test_certsrv.py
@@ -2,6 +2,8 @@ import pytest
 import certsrv
 import OpenSSL
 
+from urllib2 import HTTPError
+
 def create_csr():
     key = OpenSSL.crypto.PKey()
     key.generate_key(OpenSSL.crypto.TYPE_RSA, 2048)
@@ -107,3 +109,44 @@ def test_get_chain_der(opt_adcs, opt_username, opt_password):
     # so we just check that it is the right encoding
     assert '-----BEGIN CERTIFICATE-----' not in der_chain
  
+def test_get_cert_with_ntlm(opt_adcs, opt_username, opt_password, opt_template):
+    csr = create_csr()
+    pem_csr = OpenSSL.crypto.dump_certificate_request(OpenSSL.crypto.FILETYPE_PEM, csr)
+    pem_cert = certsrv.get_cert(opt_adcs, pem_csr, opt_template, opt_username, opt_password, auth_method='ntlm')
+    cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, pem_cert)
+    check_cert_matches_csr_and_issuer(csr, cert, opt_adcs, opt_username, opt_password)
+
+def test_get_existing_cert_with_ntlm(opt_adcs, opt_username, opt_password):
+    # Request number 1 should always exist, right?
+    pem_cert = certsrv.get_existing_cert(opt_adcs, 1, opt_username, opt_password)
+    cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, pem_cert)
+
+def test_check_credentials_with_ntlm(opt_adcs, opt_username, opt_password):
+    assert certsrv.check_credentials(opt_adcs, opt_username, opt_password, auth_method='ntlm')
+
+def test_check_wrong_credentials_with_ntlm(opt_adcs):
+    assert certsrv.check_credentials(opt_adcs, 'wronguser', 'wrongpassword', auth_method='ntlm') == False
+
+def test_get_ca_cert_with_ntlm(opt_adcs, opt_username, opt_password):
+    pem_cert = certsrv.get_ca_cert(opt_adcs, opt_username, opt_password, auth_method='ntlm')
+    cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, pem_cert)
+    # If it is the current cert, it should be valid
+    assert cert.has_expired() == False
+
+def test_get_chain_with_ntlm(opt_adcs, opt_username, opt_password):
+    pem_chain = certsrv.get_chain(opt_adcs, opt_username, opt_password, 'b64', auth_method='ntlm')
+    # pyOpenSSL does not have an option to parse PKCS#7,
+    # so we just check that it is the right encoding
+    assert '-----BEGIN CERTIFICATE-----' in pem_chain
+
+def test_wrong_credentials(opt_adcs, opt_username, opt_password):
+    with pytest.raises(HTTPError) as excinfo:
+        certsrv.get_existing_cert(opt_adcs, -1, 'wronguser', 'wrongpassword')
+    assert excinfo.value.msg == 'Unauthorized'
+
+def test_wrong_credentials_with_ntlm(opt_adcs, opt_username, opt_password):
+    # We should throw a HTTPError even when ntlm auth
+    with pytest.raises(HTTPError) as excinfo:
+        certsrv.get_existing_cert(opt_adcs, -1, 'wronguser', 'wrongpassword', auth_method='ntlm')
+    assert excinfo.value.msg == 'Unauthorized'
+


### PR DESCRIPTION
This pull-request adds NTLM-Authentication support. Therefore I've refactored the script a little bit and added the function get_response() which handles the HTTP-Request and Response in one single function. 

To use NTLM authentication python module python-ntlm 1.1.0 is required.   