### PR TITLE
ntlm authentication support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ setup(
         'Topic :: Security',
         'Topic :: Software Development :: Libraries',
         'Topic :: System :: Systems Administration',
-        ],
+    ],
+    install_requires=['python-ntlm']
 )


### PR DESCRIPTION
I needed ntlm authentication, otherwise I get 401 unauthorized response from server. So I added the ability to specify auth_type="ntlm" to the `get_cert` function