### PR TITLE
GSSAPI (Kerberos) support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-"e1839a8" = {path = ".", extras = ["ntlm"], editable = true}
+"e1839a8" = {path = ".", extras = ["ntlm","gssapi"], editable = true}
 
 [dev-packages]
 pylint = "*"

--- a/README.rst
+++ b/README.rst
@@ -29,12 +29,17 @@ Installation
     $ pip install certsrv
 
 
-Or, if you want NTLM support:
+if you want NTLM support:
 
 .. code-block:: bash
 
     $ pip install certsrv[ntlm]
 
+Or if you want GSSAPI (kerberos) support:
+
+.. code-block:: bash
+
+    $ pip install certsrv[gssapi]
 
 Documentation
 -------------

--- a/certsrv.py
+++ b/certsrv.py
@@ -10,7 +10,7 @@ import logging
 import warnings
 import requests
 
-__version__ = "2.2"
+__version__ = "2.2.0"
 
 logger = logging.getLogger(__name__)
 

--- a/certsrv.py
+++ b/certsrv.py
@@ -10,7 +10,7 @@ import logging
 import warnings
 import requests
 
-__version__ = "2.1.1"
+__version__ = "2.2"
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class Certsrv(object):
         username: The username for authentication.
         password: The password for authentication.
         auth_method: The chosen authentication method. Either 'basic' (the default),
-            'ntlm' or 'cert' (SSL client certificate).
+            'ntlm', 'cert' (SSL client certificate) or 'gssapi' (GSSAPI, Kerberos)
         cafile: A PEM file containing the CA certificates that should be trusted.
         timeout: The timeout to use against the CA server, in seconds.
             The default is 30.
@@ -101,6 +101,9 @@ class Certsrv(object):
             self.session.auth = HttpNtlmAuth(username, password)
         elif self.auth_method == "cert":
             self.session.cert = (username, password)
+        elif self.auth_method == "gssapi":
+            from requests_gssapi import HTTPSPNEGOAuth
+            self.session.auth = HTTPSPNEGOAuth()
         else:
             self.session.auth = (username, password)
 
@@ -323,7 +326,7 @@ class Certsrv(object):
             username: The username for authentication.
             password: The password for authentication.
         """
-        if self.auth_method in ("ntlm", "cert"):
+        if self.auth_method in ("ntlm", "cert", "gssapi"):
             # NTLM and SSL is connection based,
             # so we need to close the connection
             # to be able to re-authenticate
@@ -360,7 +363,7 @@ def get_cert(server, csr, template, username, password, encoding="b64", **kwargs
         encoding: The desired encoding for the returned certificate.
             Possible values are 'bin' for binary and 'b64' for Base64 (PEM).
         auth_method: The chosen authentication method. Either 'basic' (the default),
-            'ntlm' or 'cert' (ssl client certificate).
+            'ntlm', 'cert' (ssl client certificate) or 'gssapi' (GSSAPI, Kerberos).
         cafile: A PEM file containing the CA certificates that should be trusted.
 
     Returns:
@@ -398,7 +401,7 @@ def get_existing_cert(server, req_id, username, password, encoding="b64", **kwar
         encoding: The desired encoding for the returned certificate.
             Possible values are 'bin' for binary and 'b64' for Base64 (PEM).
         auth_method: The chosen authentication method. Either 'basic' (the default),
-            'ntlm' or 'cert' (ssl client certificate).
+            'ntlm', 'cert' (ssl client certificate) or 'gssapi' (GSSAPI, Kerberos).
         cafile: A PEM file containing the CA certificates that should be trusted.
 
     Returns:
@@ -431,7 +434,7 @@ def get_ca_cert(server, username, password, encoding="b64", **kwargs):
         encoding: The desired encoding for the returned certificate.
             Possible values are 'bin' for binary and 'b64' for Base64 (PEM).
         auth_method: The chosen authentication method. Either 'basic' (the default),
-            'ntlm' or 'cert' (ssl client certificate).
+            'ntlm', 'cert' (ssl client certificate) or 'gssapi' (GSSAPI, Kerberos).
         cafile: A PEM file containing the CA certificates that should be trusted.
 
     Returns:
@@ -460,7 +463,7 @@ def get_chain(server, username, password, encoding="bin", **kwargs):
         encoding: The desired encoding for the returned certificates.
             Possible values are 'bin' for binary and 'b64' for Base64 (PEM).
         auth_method: The chosen authentication method. Either 'basic' (the default),
-            'ntlm' or 'cert' (ssl client certificate).
+            'ntlm', 'cert' (ssl client certificate) or 'gssapi' (GSSAPI, Kerberos).
         cafile: A PEM file containing the CA certificates that should be trusted.
 
     Returns:
@@ -487,7 +490,7 @@ def check_credentials(server, username, password, **kwargs):
         username: The username for authentication.
         pasword: The password for authentication.
         auth_method: The chosen authentication method. Either 'basic' (the default),
-            'ntlm' or 'cert' (ssl client certificate).
+            'ntlm', 'cert' (ssl client certificate) or 'gssapi' (GSSAPI, Kerberos).
         cafile: A PEM file containing the CA certificates that should be trusted.
 
     Returns:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,9 @@ Prerequisites
 
 The IIS server must listen on HTTPS with a valid (trusted by the client)
 certificate. It is recommended to enable basic auth on IIS, but NTLM is
-also supported through the `requests_ntlm package <https://pypi.org/project/requests_ntlm/>`_
+also supported through the `requests_ntlm package <https://pypi.org/project/requests_ntlm/>`_.
+You can also use kerberos through `requests-gssapi package <https://pypi.org/project/requests-gssapi/>`_.
+for this to work, you'll need a valid TGT, which you can create using kinit
 
 Disclaimer
 ----------

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         ],
     extras_require={
         'ntlm': ['requests_ntlm'],
+        'gssapi': ['requests-gssapi'],
         },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Hello.
I've added kerberos/spnego SSO support basically just by referencing requests-gssapi library.

Tested on MacOS 10.14 connecting to Windows 2016 Certificate Services.
Just need to have a valid TGT in the kerberos credential cache