### PR TITLE
proxy support for get and post requests

### DIFF
--- a/certsrv.py
+++ b/certsrv.py
@@ -60,7 +60,9 @@ class Certsrv(object):
         cafile: A PEM file containing the CA certificates that should be trusted.
         timeout: The timeout to use against the CA server, in seconds.
             The default is 30.
-
+        proxies: Dictionary of proxy server for post of get operations
+            {'http': 'http://foo.bar:3128', 'https': 'socks5://foo.bar:1080'}
+            The default is None
     Note:
         If you use a client certificate for authentication (auth_method=cert),
         the username parameter should be the path to a certificate, and
@@ -68,12 +70,13 @@ class Certsrv(object):
     """
 
     def __init__(self, server, username, password, auth_method="basic",
-                 cafile=None, timeout=TIMEOUT):
+                 cafile=None, timeout=TIMEOUT, proxies=None):
 
         self.server = server
         self.timeout = timeout
         self.auth_method = auth_method
         self.session = requests.Session()
+        self.proxies = proxies
 
         if cafile:
             self.session.verify = cafile
@@ -105,11 +108,11 @@ class Certsrv(object):
             self.session.auth = (username, password)
 
     def _post(self, url, **kwargs):
-        response = self.session.post(url, timeout=self.timeout, **kwargs)
+        response = self.session.post(url, timeout=self.timeout, proxies=self.proxies, **kwargs)
         return self._handle_response(response)
 
     def _get(self, url, **kwargs):
-        response = self.session.get(url, timeout=self.timeout, **kwargs)
+        response = self.session.get(url, timeout=self.timeout, proxies=self.proxies, **kwargs)
         return self._handle_response(response)
 
     @staticmethod


### PR DESCRIPTION
As already mentioned in #19 I added an argument to the Certsrv class which gives the option to configure http/socks proxies.