### PR TITLE
Support Kerberos authentication

### DIFF
--- a/certsrv.py
+++ b/certsrv.py
@@ -99,6 +99,17 @@ class Certsrv(object):
             from requests_ntlm import HttpNtlmAuth
 
             self.session.auth = HttpNtlmAuth(username, password)
+        elif self.auth_method == "kerberos":
+            from requests_gssapi import HTTPSPNEGOAuth
+            import gssapi
+            oid = '1.3.6.1.5.5.2'  # SPNEGO
+            cred = gssapi.raw.acquire_cred_with_password(
+                gssapi.Name(username, gssapi.NameType.user),
+                password.encode("utf-8"),
+                mechs=[gssapi.OID.from_int_seq(oid)],
+                usage="initiate",
+            )
+            self.session.auth = HTTPSPNEGOAuth(creds=cred.creds)
         elif self.auth_method == "cert":
             self.session.cert = (username, password)
         else:


### PR DESCRIPTION
Added support of kerberos authentication due to [ntlm sunset announcement from Microsoft](https://techcommunity.microsoft.com/t5/windows-it-pro-blog/the-evolution-of-windows-authentication/ba-p/3926848). Implemenation requires the [requests_gssapi](https://github.com/pythongssapi/requests-gssapi) and [gssapi](https://github.com/pythongssapi/python-gssapi) module to be installed. Further, Kerberos must be preconfigured meaning a valid krb5.conf is expected to be present on the system.